### PR TITLE
Store multiple frames

### DIFF
--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -368,6 +368,8 @@ std::string RocksStorage::writeFrame(AtomSpace* as)
 	_rfile->Get(rocksdb::ReadOptions(), "f@" + sframe, &sid);
 	if (0 < sid.size()) return sid;
 
+	_multi_space = true;
+
 	uint64_t aid = _next_aid.fetch_add(1);
 	sid = aidtostr(aid);
 

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -2,7 +2,7 @@
  * RocksIO.cc
  * Save/restore of individual atoms.
  *
- * Copyright (c) 2020,2021 Linas Vepstas <linas@linas.org>
+ * Copyright (c) 2020,2022 Linas Vepstas <linas@linas.org>
  *
  * LICENSE:
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -218,7 +218,7 @@ static const char* aid_key = "*-NextUnusedAID-*";
 std::string RocksStorage::writeAtom(const Handle& h)
 {
 	AtomSpace* as = h->getAtomSpace();
-	if (as != _atom_space) writeFrame(as);
+	if (_atom_space and as != _atom_space) writeFrame(as);
 
 	// The issuance of new sids needs to be atomic, as otherwise we
 	// risk having the Get(pfx + satom) fail in parallel, and have

--- a/opencog/persist/rocks/RocksStorage.cc
+++ b/opencog/persist/rocks/RocksStorage.cc
@@ -37,6 +37,7 @@
 
 #include <opencog/util/Logger.h>
 #include <opencog/atoms/base/Node.h>
+#include <opencog/atomspace/AtomSpace.h>
 
 #include "RocksStorage.h"
 
@@ -124,6 +125,11 @@ void RocksStorage::init(const char * uri)
 
 printf("Rocks: opened=%s\n", file.c_str());
 printf("Rocks: initial aid=%lu\n", _next_aid.load());
+
+	// If it looks like there will be multiple AtomSpaces,
+	// then set them up now, before anything else.
+	if (0 < _atom_space->get_arity())
+		writeFrame(_atom_space);
 
 	// Set up a SID for the TV predicate key.
 	// This must match what the AtomSpace is using.

--- a/opencog/persist/rocks/RocksStorage.h
+++ b/opencog/persist/rocks/RocksStorage.h
@@ -31,6 +31,7 @@
 #define _ATOMSPACE_ROCKS_STORAGE_H
 
 #include <atomic>
+#include <map>
 #include <mutex>
 #include "rocksdb/db.h"
 
@@ -56,6 +57,9 @@ class RocksStorage : public StorageNode
 
 		// True if file contains more than one atomspace.
 		bool _multi_space;
+		std::unordered_map<AtomSpace*, const std::string> _frame_map;
+		std::mutex _mtx_frame;
+		std::string writeFrame(AtomSpace*);
 
 		// unique ID's
 		std::atomic_uint64_t _next_aid;
@@ -94,8 +98,6 @@ class RocksStorage : public StorageNode
 		void removeSatom(const std::string&, const std::string&, bool, bool);
 		void remIncoming(const std::string&, const std::string&,
 		                 const std::string&);
-
-		std::string writeFrame(AtomSpace*);
 
 		size_t count_records(const std::string&);
 

--- a/opencog/persist/rocks/RocksStorage.h
+++ b/opencog/persist/rocks/RocksStorage.h
@@ -58,8 +58,10 @@ class RocksStorage : public StorageNode
 		// True if file contains more than one atomspace.
 		bool _multi_space;
 		std::unordered_map<AtomSpace*, const std::string> _frame_map;
+		std::unordered_map<std::string, AtomSpace*> _fid_map;
 		std::mutex _mtx_frame;
 		std::string writeFrame(AtomSpace*);
+		AtomSpace* getFrame(const std::string&);
 
 		// unique ID's
 		std::atomic_uint64_t _next_aid;

--- a/opencog/persist/rocks/RocksStorage.h
+++ b/opencog/persist/rocks/RocksStorage.h
@@ -92,6 +92,8 @@ class RocksStorage : public StorageNode
 		void remIncoming(const std::string&, const std::string&,
 		                 const std::string&);
 
+		std::string writeFrame(AtomSpace*);
+
 		size_t count_records(const std::string&);
 
 	public:

--- a/opencog/persist/rocks/RocksStorage.h
+++ b/opencog/persist/rocks/RocksStorage.h
@@ -54,6 +54,9 @@ class RocksStorage : public StorageNode
 		std::string _uri;
 		rocksdb::DB* _rfile;
 
+		// True if file contains more than one atomspace.
+		bool _multi_space;
+
 		// unique ID's
 		std::atomic_uint64_t _next_aid;
 		uint64_t strtoaid(const std::string&) const;

--- a/opencog/persist/rocks/RocksStorage.h
+++ b/opencog/persist/rocks/RocksStorage.h
@@ -132,6 +132,7 @@ class RocksStorage : public StorageNode
 		void loadType(AtomSpace*, Type);
 		void loadAtomSpace(AtomSpace*); // Load entire contents
 		void storeAtomSpace(const AtomSpace*); // Store entire contents
+		Handle loadFrameDAG(AtomSpace*); // Load AtomSpace DAG
 		void barrier();
 		std::string monitor();
 

--- a/tests/persist/rocks/CMakeLists.txt
+++ b/tests/persist/rocks/CMakeLists.txt
@@ -22,5 +22,7 @@ ADD_CXXTEST(MultiPersistUTest)
 ADD_CXXTEST(MultiDeleteUTest)
 ADD_CXXTEST(QueryPersistUTest)
 #
+ADD_GUILE_TEST(SpaceFrame space-frame-test.scm)
+#
 ADD_CXXTEST(LargeFlatUTest)
 ADD_CXXTEST(LargeZipfUTest)

--- a/tests/persist/rocks/space-frame-test.scm
+++ b/tests/persist/rocks/space-frame-test.scm
@@ -1,0 +1,63 @@
+;
+; space-frame-test.scm
+; Test ability to store multiple atomspaces.
+;
+(use-modules (srfi srfi-1))
+(use-modules (opencog) (opencog test-runner))
+(use-modules (opencog persist) (opencog persist-rocks))
+
+(opencog-test-runner)
+
+; -------------------------------------------------------------------
+; Common setup, used by all tests.
+
+(define base-space (cog-atomspace))
+(define mid1-space (cog-new-atomspace base-space))
+(define mid2-space (cog-new-atomspace mid1-space))
+(define surface-space (cog-new-atomspace mid2-space))
+
+; Splatter some atoms into the various spaces.
+(cog-set-atomspace! base-space)
+(Concept "foo" (ctv 1 0 3))
+
+(cog-set-atomspace! mid1-space)
+(Concept "bar" (ctv 1 0 4))
+
+(cog-set-atomspace! mid2-space)
+(ListLink (Concept "foo") (Concept "bar") (ctv 1 0 5))
+
+(cog-set-atomspace! surface-space)
+
+; Store the content
+(define storage (RocksStorageNode "rocks:///tmp/cog-rocks-unit-test"))
+(cog-open storage)
+(store-atom (ListLink (Concept "foo") (Concept "bar")))
+(cog-close storage)
+
+; Clear out the spaces, start with a clean slate.
+(cog-atomspace-clear surface-space)
+(cog-atomspace-clear mid2-space)
+(cog-atomspace-clear mid1-space)
+(cog-atomspace-clear base-space)
+
+; -------------------------------------------------------------------
+; Test that deep links are found correctly.
+
+(define deep-link "test deep links")
+(test-begin deep-link)
+
+; Load everything.
+(cog-set-atomspace! surface-space)
+(set! storage (RocksStorageNode "rocks:///tmp/cog-rocks-unit-test"))
+(cog-open storage)
+(load-atomspace)
+(cog-close storage)
+
+; Wwork on the current surface, but expect to find the deeper ListLink.
+(define lilly (ListLink (Concept "foo") (Concept "bar")))
+
+(test-equal "link-space" mid2-space (cog-atomspace lilly))
+(test-equal "foo-space" base-space (cog-atomspace (gar lilly)))
+(test-equal "bar-space" mid1-space (cog-atomspace (gdr lilly)))
+
+(test-end deep-link)

--- a/tests/persist/rocks/space-frame-test.scm
+++ b/tests/persist/rocks/space-frame-test.scm
@@ -119,25 +119,32 @@
 	; Load everything.
 	(define storage (RocksStorageNode "rocks:///tmp/cog-rocks-unit-test"))
 	(cog-open storage)
-(define surface (load-frames))
+
+	; Load all of the AtomSpaces.
+	(define surface (load-frames))
+	(cog-set-atomspace! surface)
+
+	; Now load the AtomSpace itself
 	(load-atomspace)
 	(cog-close storage)
 
 	; Work on the current surface, but expect to find the deeper ListLink.
 	(define lilly (ListLink (Concept "foo") (Concept "bar")))
 
-(format #t "duude found ~A\n" lilly)
-#! ========
 	; Verify appropriate atomspace membership
-	(test-equal "link-space" mid2-space (cog-atomspace lilly))
-	(test-equal "foo-space" base-space (cog-atomspace (gar lilly)))
-	(test-equal "bar-space" mid1-space (cog-atomspace (gdr lilly)))
+	; Note that the new surface corresponds to the older mid2-space.
+	; This is because the old surface-space was never actually stored
+	; and thus is never restored. The top-most space of the restored
+	; hiearchy is the old mid2-space.
+	(define mid-space (cog-outgoing-atom surface 0))
+	(test-equal "link-space" surface (cog-atomspace lilly))
+	(test-equal "foo-space" new-base (cog-atomspace (gar lilly)))
+	(test-equal "bar-space" mid-space (cog-atomspace (gdr lilly)))
 
 	; Verify appropriate values
 	(test-equal "base-tv" 3 (get-cnt (cog-node 'Concept "foo")))
 	(test-equal "mid1-tv" 4 (get-cnt (cog-node 'Concept "bar")))
 	(test-equal "mid2-tv" 5 (get-cnt lilly))
-===== !#
 )
 
 (define fresh-link "test fresh link restore")

--- a/tests/persist/rocks/space-frame-test.scm
+++ b/tests/persist/rocks/space-frame-test.scm
@@ -8,6 +8,25 @@
 
 (opencog-test-runner)
 
+; Delete the directory `dirname` and everything in it.
+; I don't understand why scheme doesn't provide this, built-in.
+(define (whack dirname)
+	(define (unlink dir)
+		(define fname (readdir dir))
+		(when (not (eof-object? fname))
+			(let ((fpath (string-append dirname "/" fname)))
+				(when (equal? 'regular (stat:type (stat fpath)))
+					(delete-file fpath))
+				(unlink dir))))
+
+	(when (access? dirname F_OK)
+		(let ((dir (opendir dirname)))
+			(unlink dir)
+			(closedir dir)
+			(rmdir dirname))))
+
+(whack "/tmp/cog-rocks-unit-test")
+
 ; -------------------------------------------------------------------
 ; Common setup, used by all tests.
 
@@ -59,5 +78,7 @@
 (test-equal "link-space" mid2-space (cog-atomspace lilly))
 (test-equal "foo-space" base-space (cog-atomspace (gar lilly)))
 (test-equal "bar-space" mid1-space (cog-atomspace (gdr lilly)))
+
+(whack "/tmp/cog-rocks-unit-test")
 
 (test-end deep-link)

--- a/tests/persist/rocks/space-frame-test.scm
+++ b/tests/persist/rocks/space-frame-test.scm
@@ -117,14 +117,16 @@
 	(cog-set-atomspace! new-base)
 
 	; Load everything.
-	(set! storage (RocksStorageNode "rocks:///tmp/cog-rocks-unit-test"))
+	(define storage (RocksStorageNode "rocks:///tmp/cog-rocks-unit-test"))
 	(cog-open storage)
+(define surface (load-frames))
 	(load-atomspace)
 	(cog-close storage)
 
 	; Work on the current surface, but expect to find the deeper ListLink.
 	(define lilly (ListLink (Concept "foo") (Concept "bar")))
 
+(format #t "duude found ~A\n" lilly)
 #! ========
 	; Verify appropriate atomspace membership
 	(test-equal "link-space" mid2-space (cog-atomspace lilly))

--- a/tests/persist/rocks/space-frame-test.scm
+++ b/tests/persist/rocks/space-frame-test.scm
@@ -91,3 +91,6 @@
 (whack "/tmp/cog-rocks-unit-test")
 
 (test-end deep-link)
+
+; ===================================================================
+(opencog-test-end)

--- a/tests/persist/rocks/space-frame-test.scm
+++ b/tests/persist/rocks/space-frame-test.scm
@@ -47,10 +47,13 @@
 
 (cog-set-atomspace! surface-space)
 
-; Store the content
+; Store the content. Store the Concepts as well as the link,
+; as otherwise, the TV's on the Concepts aren't stored.
 (define storage (RocksStorageNode "rocks:///tmp/cog-rocks-unit-test"))
 (cog-open storage)
 (store-atom (ListLink (Concept "foo") (Concept "bar")))
+(store-atom (Concept "foo"))
+(store-atom (Concept "bar"))
 (cog-close storage)
 
 ; Clear out the spaces, start with a clean slate.

--- a/tests/persist/rocks/space-frame-test.scm
+++ b/tests/persist/rocks/space-frame-test.scm
@@ -35,62 +35,114 @@
 (define mid2-space (cog-new-atomspace mid1-space))
 (define surface-space (cog-new-atomspace mid2-space))
 
-; Splatter some atoms into the various spaces.
-(cog-set-atomspace! base-space)
-(Concept "foo" (ctv 1 0 3))
+(define (setup-and-store)
+	; Splatter some atoms into the various spaces.
+	(cog-set-atomspace! base-space)
+	(Concept "foo" (ctv 1 0 3))
 
-(cog-set-atomspace! mid1-space)
-(Concept "bar" (ctv 1 0 4))
+	(cog-set-atomspace! mid1-space)
+	(Concept "bar" (ctv 1 0 4))
 
-(cog-set-atomspace! mid2-space)
-(ListLink (Concept "foo") (Concept "bar") (ctv 1 0 5))
+	(cog-set-atomspace! mid2-space)
+	(ListLink (Concept "foo") (Concept "bar") (ctv 1 0 5))
 
-(cog-set-atomspace! surface-space)
+	(cog-set-atomspace! surface-space)
 
-; Store the content. Store the Concepts as well as the link,
-; as otherwise, the TV's on the Concepts aren't stored.
-(define storage (RocksStorageNode "rocks:///tmp/cog-rocks-unit-test"))
-(cog-open storage)
-(store-atom (ListLink (Concept "foo") (Concept "bar")))
-(store-atom (Concept "foo"))
-(store-atom (Concept "bar"))
-(cog-close storage)
+	; Store the content. Store the Concepts as well as the link,
+	; as otherwise, the TV's on the Concepts aren't stored.
+	(define storage (RocksStorageNode "rocks:///tmp/cog-rocks-unit-test"))
+	(cog-open storage)
+	(store-atom (ListLink (Concept "foo") (Concept "bar")))
+	(store-atom (Concept "foo"))
+	(store-atom (Concept "bar"))
+	(cog-close storage)
 
-; Clear out the spaces, start with a clean slate.
-(cog-atomspace-clear surface-space)
-(cog-atomspace-clear mid2-space)
-(cog-atomspace-clear mid1-space)
-(cog-atomspace-clear base-space)
+	; Clear out the spaces, start with a clean slate.
+	(cog-atomspace-clear surface-space)
+	(cog-atomspace-clear mid2-space)
+	(cog-atomspace-clear mid1-space)
+	(cog-atomspace-clear base-space)
+)
+
+; Destroy the atomspaces
+(define (zap-spaces)
+	(set! surface-space #f)
+	(set! mid2-space #f)
+	(set! mid1-space #f)
+	(set! base-space #f)
+)
+
+(define (get-cnt ATOM) (inexact->exact (cog-count ATOM)))
 
 ; -------------------------------------------------------------------
 ; Test that deep links are found correctly.
 
+(define (test-deep-link)
+	(setup-and-store)
+
+	; Load everything.
+	(cog-set-atomspace! surface-space)
+	(define storage (RocksStorageNode "rocks:///tmp/cog-rocks-unit-test"))
+	(cog-open storage)
+	(load-atomspace)
+	(cog-close storage)
+
+	; Work on the current surface, but expect to find the deeper ListLink.
+	(define lilly (ListLink (Concept "foo") (Concept "bar")))
+
+	; Verify appropriate atomspace membership
+	(test-equal "link-space" mid2-space (cog-atomspace lilly))
+	(test-equal "foo-space" base-space (cog-atomspace (gar lilly)))
+	(test-equal "bar-space" mid1-space (cog-atomspace (gdr lilly)))
+
+	; Verify appropriate values
+	(test-equal "base-tv" 3 (get-cnt (cog-node 'Concept "foo")))
+	(test-equal "mid1-tv" 4 (get-cnt (cog-node 'Concept "bar")))
+	(test-equal "mid2-tv" 5 (get-cnt lilly))
+)
+
 (define deep-link "test deep links")
 (test-begin deep-link)
-
-; Load everything.
-(cog-set-atomspace! surface-space)
-(set! storage (RocksStorageNode "rocks:///tmp/cog-rocks-unit-test"))
-(cog-open storage)
-(load-atomspace)
-(cog-close storage)
-
-; Work on the current surface, but expect to find the deeper ListLink.
-(define lilly (ListLink (Concept "foo") (Concept "bar")))
-
-; Verify appropriate atomspace membership
-(test-equal "link-space" mid2-space (cog-atomspace lilly))
-(test-equal "foo-space" base-space (cog-atomspace (gar lilly)))
-(test-equal "bar-space" mid1-space (cog-atomspace (gdr lilly)))
-
-; Verify appropriate values
-(test-equal "base-tv" 3 (inexact->exact (cog-count (cog-node 'Concept "foo"))))
-(test-equal "mid1-tv" 4 (inexact->exact (cog-count (cog-node 'Concept "bar"))))
-(test-equal "mid2-tv" 5 (inexact->exact (cog-count lilly)))
-
-(whack "/tmp/cog-rocks-unit-test")
-
+(test-deep-link)
 (test-end deep-link)
 
+; -------------------------------------------------------------------
+; Same as above, except without the pre-existing atomspace hierachty.
+
+(define (test-fresh-link)
+	(setup-and-store)
+	(zap-spaces)
+
+	(define new-base (cog-new-atomspace))
+	(cog-set-atomspace! new-base)
+
+	; Load everything.
+	(set! storage (RocksStorageNode "rocks:///tmp/cog-rocks-unit-test"))
+	(cog-open storage)
+	(load-atomspace)
+	(cog-close storage)
+
+	; Work on the current surface, but expect to find the deeper ListLink.
+	(define lilly (ListLink (Concept "foo") (Concept "bar")))
+
+#! ========
+	; Verify appropriate atomspace membership
+	(test-equal "link-space" mid2-space (cog-atomspace lilly))
+	(test-equal "foo-space" base-space (cog-atomspace (gar lilly)))
+	(test-equal "bar-space" mid1-space (cog-atomspace (gdr lilly)))
+
+	; Verify appropriate values
+	(test-equal "base-tv" 3 (get-cnt (cog-node 'Concept "foo")))
+	(test-equal "mid1-tv" 4 (get-cnt (cog-node 'Concept "bar")))
+	(test-equal "mid2-tv" 5 (get-cnt lilly))
+===== !#
+)
+
+(define fresh-link "test fresh link restore")
+(test-begin fresh-link)
+(test-fresh-link)
+(test-end fresh-link)
+
 ; ===================================================================
+(whack "/tmp/cog-rocks-unit-test")
 (opencog-test-end)

--- a/tests/persist/rocks/space-frame-test.scm
+++ b/tests/persist/rocks/space-frame-test.scm
@@ -72,12 +72,18 @@
 (load-atomspace)
 (cog-close storage)
 
-; Wwork on the current surface, but expect to find the deeper ListLink.
+; Work on the current surface, but expect to find the deeper ListLink.
 (define lilly (ListLink (Concept "foo") (Concept "bar")))
 
+; Verify appropriate atomspace membership
 (test-equal "link-space" mid2-space (cog-atomspace lilly))
 (test-equal "foo-space" base-space (cog-atomspace (gar lilly)))
 (test-equal "bar-space" mid1-space (cog-atomspace (gdr lilly)))
+
+; Verify appropriate values
+(test-equal "base-tv" 3 (inexact->exact (cog-count (cog-node 'Concept "foo"))))
+(test-equal "mid1-tv" 4 (inexact->exact (cog-count (cog-node 'Concept "bar"))))
+(test-equal "mid2-tv" 5 (inexact->exact (cog-count lilly)))
 
 (whack "/tmp/cog-rocks-unit-test")
 


### PR DESCRIPTION
Allow multiple AtomSpaces to be stored. Each different AtomSpace can be thought of as a "frame", kind-of-like a stack-frame in C/C++ or like a kripke frame in logic. Frames can also be thought of as "contexts" for truth-values, so that truth values can be different in different frames. 

This adds preliminary support. A basic unit test passes. Atom deletion does not yet work correctly. 