### PR TITLE
Not hide atoms

### DIFF
--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1050,7 +1050,7 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 			newkey.substr(); // do some string stuff
 			_rfile->Put(rocksdb::WriteOptions(), newkey, "");
 		} else {
-			// 1. find the "a@ record and delete"
+			// 1. find the "a@ record and delete" (see lines 1009-1019)
 			// 2. delete the "k@" record
 		}
 	}

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1022,7 +1022,13 @@ void RocksStorage::removeSatom(const std::string& satom,
 void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h, 
 					bool recursive, bool extracted)
 {
+	std::string pfx = "k@";
+	size_t cnt = 0;
+	auto it = _rfile->NewIterator(rocksdb::ReadOptions());
 
+	for (it->Seek(pfx); it->Valid() and it->key().starts_with(pfx); it->Next()){
+		
+	}
 }
 
 // =========================================================

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -398,7 +398,7 @@ void RocksStorage::storeAtom(const Handle& h, bool synchronous)
 		storeValue(cid + writeAtom(key), h->getValue(key));
 }
 
-void RocksStorage::storeMissingAtom(AtomSpace* as, const Handle& h)
+void RocksStorage::storeMissingAtom(AtomSpace* as, const Handle& h, bool tmpMarker)
 {
 	std::string sid = writeAtom(h, false);
 
@@ -414,7 +414,8 @@ void RocksStorage::storeMissingAtom(AtomSpace* as, const Handle& h)
 	_rfile->Delete(rocksdb::WriteOptions(), marker);
 
 	// Store an intentionally invalid key.
-	_rfile->Put(rocksdb::WriteOptions(), skid + "-1", "");
+	marker = skid + (tmpMarker ? "-2" : "-1");
+	_rfile->Put(rocksdb::WriteOptions(), marker, "");
 }
 
 void RocksStorage::storeValue(const std::string& skid,
@@ -799,7 +800,7 @@ void RocksStorage::removeAtom(AtomSpace* frame, const Handle& h, bool recursive)
 	}
 
 	// Multi-space Atom remove is done via hiding...
-	storeMissingAtom(frame, h);
+	storeMissingAtom(frame, h, true);
 }
 
 void RocksStorage::doRemoveAtom(const Handle& h, bool recursive)

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1060,7 +1060,7 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 			// single frame case
 			// just look what happens with the samples
 			// do we call "removeSatom" or its calling function "doRemoveAtom"  ?: 
-			removeSatom(satom, akey, h->is_node(), recursive);
+			// removeSatom(satom, akey, h->is_node(), recursive);
 
 			// alternative: 
 			// 1. find the "a@ record and delete" (see lines 1009-1019)
@@ -1068,11 +1068,15 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 			// yes, I think we should delete "n@", they are the same as "a@" with rev. order!
 			// do we need do check if this exists ?
 			// or maybe use "removeSatom" ?
+			// also maybe hash has to be removed
 			// _rfile->Delete(rocksdb::WriteOptions(), akey);
+			std::string nlpfx = h->is_node() ? "n@" : "l@";
+			_rfile->Delete(rocksdb::WriteOptions(), nlpfx + satom);
+			_rfile->Delete(rocksdb::WriteOptions(), akey);
+
 			// 2. delete the "k@" record
 			// have to be careful, we have to delete the DB entry our loop is sitting on ....!
-			// _rfile->Delete(rocksdb::WriteOptions(), it->key());
-			
+			_rfile->Delete(rocksdb::WriteOptions(), it->key());
 		}
 	}
 }

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1028,12 +1028,12 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 	auto it = _rfile->NewIterator(rocksdb::ReadOptions());
 
 	for (it->Seek(pfx); it->Valid() and it->key().starts_with(pfx) and it->key().ends_with(sfx); it->Next()){
-		std::string vkey = it->key().ToString();
-		vkey[0] = 'a';
-		vkey.resize(vkey.find(':') + 1);
+		std::string akey = it->key().ToString();
+		akey[0] = 'a';
+		akey.resize(vkey.find(':') + 1);
 		
 		std::string satom;
-		rocksdb::Status s = _rfile->Get(rocksdb::ReadOptions(), vkey,  &satom);
+		rocksdb::Status s = _rfile->Get(rocksdb::ReadOptions(), akey,  &satom);
 		if (not s.ok())
 			throw IOException(TRACE_INFO, "Internal Error!");
 		

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1041,6 +1041,18 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 		// it looks like in decode_atom a function decode_frame is called
 		// but atm this is a wild guess ()
 		Handle h = Sexpr::decode_atom(satom);
+
+		// Atom::isAbsent is private atm, is this a problem ...?
+		if (h->isAbsent()){
+			_rfile->Delete(rocksdb::WriteOptions(), it->key());
+			// Store an intentionally invalid key.
+			std::string newkey = it->key().ToString();
+			newkey.substr(); // do some string stuff
+			_rfile->Put(rocksdb::WriteOptions(), newkey, "");
+		} else {
+			// 1. find the "a@ record and delete"
+			// 2. delete the "k@" record
+		}
 	}
 }
 

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1028,7 +1028,15 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 	auto it = _rfile->NewIterator(rocksdb::ReadOptions());
 
 	for (it->Seek(pfx); it->Valid() and it->key().starts_with(pfx) and it->key().ends_with(sfx); it->Next()){
+		std::string vkey = it->key().ToString();
+		vkey[0] = 'a';
+		vkey.resize(vkey.find(':') + 1);
 		
+		std::string satom;
+		rocksdb::Status s = _rfile->Get(rocksdb::ReadOptions(), vkey,  &satom);
+		if (not s.ok())
+			throw IOException(TRACE_INFO, "Internal Error!");
+
 	}
 }
 

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1036,7 +1036,11 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 		rocksdb::Status s = _rfile->Get(rocksdb::ReadOptions(), vkey,  &satom);
 		if (not s.ok())
 			throw IOException(TRACE_INFO, "Internal Error!");
-
+		
+		// don't know if this is enough to get the atom from the correct frame
+		// it looks like in decode_atom a function decode_frame is called
+		// but atm this is a wild guess ()
+		Handle h = Sexpr::decode_atom(satom);
 	}
 }
 

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1047,10 +1047,10 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 		// also if extracted is false (some error in As extract function),
 		// we also set back to -1 in DB (as it was before)
 		if (not extracted or isAtomAbsent(h)){
+			std::string newkey = it->key().ToString();			
+			// replace "-2" with "-1"			
+			newkey = newkey.substr(newkey.size() - 2) + "-1";			
 			_rfile->Delete(rocksdb::WriteOptions(), it->key());
-			// replace "-2" with "-1"
-			std::string newkey = it->key().ToString();
-			newkey = newkey.substr(newkey.size() - 2) + "-1";
 			_rfile->Put(rocksdb::WriteOptions(), newkey, "");
 		} else {
 			// First: try if it we can use the function for the

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1030,7 +1030,7 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 	for (it->Seek(pfx); it->Valid() and it->key().starts_with(pfx) and it->key().ends_with(sfx); it->Next()){
 		std::string akey = it->key().ToString();
 		akey[0] = 'a';
-		akey.resize(vkey.find(':') + 1);
+		akey.resize(akey.find(':') + 1);
 		
 		std::string satom;
 		rocksdb::Status s = _rfile->Get(rocksdb::ReadOptions(), akey,  &satom);

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1051,6 +1051,8 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 			_rfile->Put(rocksdb::WriteOptions(), newkey, "");
 		} else {
 			// 1. find the "a@ record and delete" (see lines 1009-1019)
+			// do we have to worry also about "n@" : "l@" ?
+			_rfile->Delete(rocksdb::WriteOptions(), akey);
 			// 2. delete the "k@" record
 		}
 	}

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1028,7 +1028,10 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 	
 	auto it = _rfile->NewIterator(rocksdb::ReadOptions());
 
-	for (it->Seek(pfx); it->Valid() and it->key().starts_with(pfx) and it->key().ends_with(sfx); it->Next()){
+	for (it->Seek(pfx); it->Valid() and it->key().starts_with(pfx); it->Next()){
+		if (not it->key().ends_with(sfx))
+			continue;
+
 		std::string akey = it->key().ToString();
 		akey[0] = 'a';
 		akey.resize(akey.find(':') + 1);

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1019,6 +1019,12 @@ void RocksStorage::removeSatom(const std::string& satom,
 	delete it;
 }
 
+void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h, 
+					bool recursive, bool extracted)
+{
+
+}
+
 // =========================================================
 // Work with the incoming set
 

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1052,8 +1052,11 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 		} else {
 			// 1. find the "a@ record and delete" (see lines 1009-1019)
 			// do we have to worry also about "n@" : "l@" ?
+			// do we need do check if this exists ?
 			_rfile->Delete(rocksdb::WriteOptions(), akey);
 			// 2. delete the "k@" record
+			// have to be careful, we have to delete the DB entry our loop is sitting on ....!
+			_rfile->Delete(rocksdb::WriteOptions(), it->key());
 		}
 	}
 }

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1019,6 +1019,7 @@ void RocksStorage::removeSatom(const std::string& satom,
 	delete it;
 }
 
+// under construction...
 void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h, 
 					bool recursive, bool extracted)
 {
@@ -1052,15 +1053,23 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 			newkey = newkey.substr(newkey.size() - 2) + "-1";
 			_rfile->Put(rocksdb::WriteOptions(), newkey, "");
 		} else {
+			// First: try if it we can use the function for the
+			// single frame case
+			// just look what happens with the samples
+			// do we call "removeSatom" or its calling function "doRemoveAtom"  ?: 
+			removeSatom(satom, akey, h->is_node(), recursive);
+
+			// alternative: 
 			// 1. find the "a@ record and delete" (see lines 1009-1019)
 			// do we have to worry also about "n@" : "l@" ?
 			// yes, I think we should delete "n@", they are the same as "a@" with rev. order!
 			// do we need do check if this exists ?
 			// or maybe use "removeSatom" ?
-			_rfile->Delete(rocksdb::WriteOptions(), akey);
+			// _rfile->Delete(rocksdb::WriteOptions(), akey);
 			// 2. delete the "k@" record
 			// have to be careful, we have to delete the DB entry our loop is sitting on ....!
-			_rfile->Delete(rocksdb::WriteOptions(), it->key());
+			// _rfile->Delete(rocksdb::WriteOptions(), it->key());
+			
 		}
 	}
 }

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1041,7 +1041,7 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 		// don't know if this is enough to get the atom from the correct frame
 		// it looks like in decode_atom a function decode_frame is called
 		// but atm this is a wild guess ()
-		Handle h = Sexpr::decode_atom(satom.substr(2));
+		Handle h = Sexpr::decode_atom(satom);
 
 		// Atom::isAbsent is private atm, is this a problem ...?
 		// also if extracted is false (some error in As extract function),

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1023,10 +1023,11 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 					bool recursive, bool extracted)
 {
 	std::string pfx = "k@";
+	std::string sfx = "-2";
 	size_t cnt = 0;
 	auto it = _rfile->NewIterator(rocksdb::ReadOptions());
 
-	for (it->Seek(pfx); it->Valid() and it->key().starts_with(pfx); it->Next()){
+	for (it->Seek(pfx); it->Valid() and it->key().starts_with(pfx) and it->key().ends_with(sfx); it->Next()){
 		
 	}
 }

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1024,7 +1024,7 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 {
 	std::string pfx = "k@";
 	std::string sfx = "-2";
-	size_t cnt = 0;
+	
 	auto it = _rfile->NewIterator(rocksdb::ReadOptions());
 
 	for (it->Seek(pfx); it->Valid() and it->key().starts_with(pfx) and it->key().ends_with(sfx); it->Next()){
@@ -1040,7 +1040,7 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 		// don't know if this is enough to get the atom from the correct frame
 		// it looks like in decode_atom a function decode_frame is called
 		// but atm this is a wild guess ()
-		Handle h = Sexpr::decode_atom(satom);
+		Handle h = Sexpr::decode_atom(satom.substr(2));
 
 		// Atom::isAbsent is private atm, is this a problem ...?
 		// also if extracted is false (some error in As extract function),
@@ -1054,7 +1054,9 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 		} else {
 			// 1. find the "a@ record and delete" (see lines 1009-1019)
 			// do we have to worry also about "n@" : "l@" ?
+			// yes, I think we should delete "n@", they are the same as "a@" with rev. order!
 			// do we need do check if this exists ?
+			// or maybe use "removeSatom" ?
 			_rfile->Delete(rocksdb::WriteOptions(), akey);
 			// 2. delete the "k@" record
 			// have to be careful, we have to delete the DB entry our loop is sitting on ....!

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1045,7 +1045,7 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 		// Atom::isAbsent is private atm, is this a problem ...?
 		// also if extracted is false (some error in As extract function),
 		// we also set back to -1 in DB (as it was before)
-		if (not extracted or h->isAbsent()){
+		if (not extracted or isAtomAbsent(h)){
 			_rfile->Delete(rocksdb::WriteOptions(), it->key());
 			// replace "-2" with "-1"
 			std::string newkey = it->key().ToString();

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1045,9 +1045,9 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 		// Atom::isAbsent is private atm, is this a problem ...?
 		if (h->isAbsent()){
 			_rfile->Delete(rocksdb::WriteOptions(), it->key());
-			// Store an intentionally invalid key.
+			// replace "-2" with "-1"
 			std::string newkey = it->key().ToString();
-			newkey.substr(); // do some string stuff
+			newkey = newkey.substr(newkey.size() - 2) + "-1";
 			_rfile->Put(rocksdb::WriteOptions(), newkey, "");
 		} else {
 			// 1. find the "a@ record and delete" (see lines 1009-1019)

--- a/opencog/persist/rocks/RocksIO.cc
+++ b/opencog/persist/rocks/RocksIO.cc
@@ -1043,7 +1043,9 @@ void RocksStorage::postRemoveAtom(AtomSpace* as, const Handle& h,
 		Handle h = Sexpr::decode_atom(satom);
 
 		// Atom::isAbsent is private atm, is this a problem ...?
-		if (h->isAbsent()){
+		// also if extracted is false (some error in As extract function),
+		// we also set back to -1 in DB (as it was before)
+		if (not extracted or h->isAbsent()){
 			_rfile->Delete(rocksdb::WriteOptions(), it->key());
 			// replace "-2" with "-1"
 			std::string newkey = it->key().ToString();

--- a/opencog/persist/rocks/RocksStorage.h
+++ b/opencog/persist/rocks/RocksStorage.h
@@ -149,6 +149,7 @@ class RocksStorage : public StorageNode
 		void preRemoveAtom(AtomSpace* as, const Handle& h, bool recursive) {
 			return removeAtom(as, h, recursive);
 		}
+		void postRemoveAtom(AtomSpace* as, const Handle& h, bool recursive, bool extracted);
 		void storeValue(const Handle& atom, const Handle& key);
 		void updateValue(const Handle&, const Handle&, const ValuePtr&);
 		void loadValue(const Handle& atom, const Handle& key);

--- a/opencog/persist/rocks/RocksStorage.h
+++ b/opencog/persist/rocks/RocksStorage.h
@@ -146,6 +146,9 @@ class RocksStorage : public StorageNode
 		void fetchIncomingByType(AtomSpace*, const Handle&, Type t);
 		void storeAtom(const Handle&, bool synchronous = false);
 		void removeAtom(AtomSpace*, const Handle&, bool recursive);
+		void preRemoveAtom(AtomSpace* as, const Handle& h, bool recursive) {
+			return removeAtom(as, h, recursive);
+		}
 		void storeValue(const Handle& atom, const Handle& key);
 		void updateValue(const Handle&, const Handle&, const ValuePtr&);
 		void loadValue(const Handle& atom, const Handle& key);

--- a/opencog/persist/rocks/RocksStorage.h
+++ b/opencog/persist/rocks/RocksStorage.h
@@ -96,7 +96,7 @@ class RocksStorage : public StorageNode
 		void remFromSidList(const std::string&, const std::string&);
 		void storeValue(const std::string& skid,
 		                const ValuePtr& vp);
-		void storeMissingAtom(AtomSpace*, const Handle&);
+		void storeMissingAtom(AtomSpace*, const Handle&, bool tmpMarker = false);
 		void doRemoveAtom(const Handle&, bool recursive);
 
 		ValuePtr getValue(const std::string&);


### PR DESCRIPTION
THIS IS A DRAFT! DO NOT MERGE!

This code is work in progress and I might still have some misconceptions.   

The main thing happens in `RocksStorage::postRemoveAtom` in `opencog/persist/rocks/RocksIO.cc`: Look if we have marked an entry in Rocks (atm still '-2', but this can be changed as mentioned earlier). Then check in AS if it is absent and delete if necessary.

This is not meant to compile yet and some smaller parts might still be missing...
